### PR TITLE
UCAPI-114 Scala, plugins and library updates

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,13 @@
+rules = [ExplicitResultTypes, OrganizeImports, RemoveUnused, DisableSyntax]
+
+OrganizeImports {
+  targetDialect = Scala2
+  groupedImports = Keep
+  coalesceToWildcardImportThreshold = 5
+}
+
+DisableSyntax {
+  noVars = true
+  noNulls = true
+  noReturns = true
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,6 @@
-version = 3.7.3
+version = 3.10.2
+runner.dialect = scala213
+
 maxColumn = 120
 binPack.parentConstructors = false
 indent.callSite = 2
@@ -18,6 +20,5 @@ rewrite.redundantBraces.maxBreaks = 100
 rewrite.imports.sort = ascii
 newlines.sometimesBeforeColonInMethodReturnType = true
 newlines.penalizeSingleSelectMultiArgList = false
-runner.dialect = scala213
 importSelectors = singleLine
 project.git = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.10.2
+version = 3.10.3
 runner.dialect = scala213
 
 maxColumn = 120

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**This is a template README.md.  Be sure to update this with project specific content that describes your performance test project.**
-
 # universal-credit-liability-performance-tests
 
 Performance test suite for the `<digital service name>`, using [performance-test-runner](https://github.com/hmrc/performance-test-runner) under the hood.

--- a/build.sbt
+++ b/build.sbt
@@ -9,5 +9,12 @@ lazy val root = (project in file("."))
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
     // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
     Test / testOptions := Seq.empty,
+    // JVM args for Java 17/21 compatibility
+    // Resolves issue "IllegalAccessException: module java.base does not open java.lang to unnamed module"
+    // https://github.com/gatling/gatling/issues/4599
+    Gatling / javaOptions ++= Seq(
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "--add-opens=java.base/java.io=ALL-UNNAMED"
+    ),
     libraryDependencies ++= Dependencies.test
   )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file("."))
     name := "universal-credit-liability-performance-tests",
     version := "0.1.0-SNAPSHOT",
     scalaVersion := "2.13.18",
-    //implicitConversions & postfixOps are Gatling recommended -language settings
+    // implicitConversions & postfixOps are Gatling recommended -language settings
     scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
     // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
@@ -16,5 +16,9 @@ lazy val root = (project in file("."))
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.io=ALL-UNNAMED"
     ),
-    libraryDependencies ++= Dependencies.test
+    libraryDependencies ++= Dependencies.test,
+    // Scalafix / SemanticDB settings
+    scalafixConfigSettings(Gatling),
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision // only required for Scala 2.x
   )

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "universal-credit-liability-performance-tests",
     version := "0.1.0-SNAPSHOT",
-    scalaVersion := "2.13.17",
+    scalaVersion := "2.13.18",
     //implicitConversions & postfixOps are Gatling recommended -language settings
     scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.

--- a/build.sbt
+++ b/build.sbt
@@ -22,3 +22,6 @@ lazy val root = (project in file("."))
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision // only required for Scala 2.x
   )
+
+addCommandAlias("prePrChecks", "; scalafmtCheckAll; scalafmtSbtCheck; scalafixAll --check")
+addCommandAlias("lintCode", "; scalafmtAll; scalafmtSbt; scalafixAll")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   val test = Seq(
-    "uk.gov.hmrc"          %% "performance-test-runner"   % "6.3.0"         % Test
+    "uk.gov.hmrc" %% "performance-test-runner" % "6.3.0" % Test
   )
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.10
+sbt.version=1.12.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-
-addSbtPlugin("io.gatling" % "gatling-sbt" % "4.9.2")
-
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.9.2")
+addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.2")
+addSbtPlugin("uk.gov.hmrc"    % "sbt-auto-build"         % "3.24.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,6 @@ addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.9.2")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.4")
 addSbtPlugin("uk.gov.hmrc"    % "sbt-auto-build"         % "3.24.0")
+
+// Scala module 2.16.1 requires Jackson Databind version >= 2.16.0 and < 2.17.0
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.16.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"           % "0.14.5")
 addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.9.2")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,5 +5,5 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.9.2")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.2")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.4")
 addSbtPlugin("uk.gov.hmrc"    % "sbt-auto-build"         % "3.24.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.9.2")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.4")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.6")
 addSbtPlugin("uk.gov.hmrc"    % "sbt-auto-build"         % "3.24.0")
 
 // Scala module 2.16.1 requires Jackson Databind version >= 2.16.0 and < 2.17.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 )
 
 addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"           % "0.14.5")
-addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.9.2")
+addSbtPlugin("io.gatling"     % "gatling-sbt"            % "4.15.0")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"           % "2.5.6")
 addSbtPlugin("uk.gov.hmrc"    % "sbt-auto-build"         % "3.24.0")


### PR DESCRIPTION
- Updated Scala to 2.13.18
- Updated sbt to 1.12.0
- Updated plugins and libraries to latest libraries
- Added Scalafix
- Updated Scalafmt .conf file
- Added fix to issue "IllegalAccessException: module java.base does not open java.lang to unnamed module" caused by the ugprade to latest `performance-test-runner`
- Added sbt aliases (`prePrChecks` and `lintCode`)