### PR TITLE
UCAPI-132 Added valid (3-40 chars) originator id

### DIFF
--- a/src/test/scala/uk/gov/hmrc/universalcreditliabilityapi/NotificationRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/universalcreditliabilityapi/NotificationRequests.scala
@@ -30,7 +30,7 @@ object NotificationRequests extends ServicesConfiguration {
   private val route: String   = "/notification"
 
   private val authToken: String    = AuthHelper.getAuthToken
-  private val originatorId: String = ""
+  private val govUkOriginatorId: String = "gov-uk-originator-id"
 
   val randomCorrelationIDs: Iterator[Map[String, String]] =
     Iterator.continually(Map("correlationId" -> UUID.randomUUID().toString))
@@ -58,7 +58,7 @@ object NotificationRequests extends ServicesConfiguration {
         Map(
           "authorization"        -> authToken,
           "content-type"         -> "application/json",
-          "gov-uk-originator-id" -> originatorId,
+          "gov-uk-originator-id" -> govUkOriginatorId,
           "correlationId"        -> "#{correlationId}" // Gatling Expression Language extracts correlationId from Feeder
         )
       )


### PR DESCRIPTION
After adding validation for the `govUkOriginatorId` to the API, we changed the empty String value to a valid (3 to 40 characters long) String.